### PR TITLE
Fix compile error with 2 parameter scope macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ macro_rules! scope {
 		let _scope = $crate::MicroProfileDroppable{};
 	};
 	($group_name:expr, $scope_name:expr) => {
-		scope!($group_name, $scope_name, 0);
+		$crate::scope!($group_name, $scope_name, 0);
 	}
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ macro_rules! scope {
 				INIT.call_once(||{
 					let group = std::ffi::CString::new($group_name).unwrap();
 					let scope = std::ffi::CString::new($scope_name).unwrap();
-					TOKEN = $crate::MicroProfileGetToken(group.as_ptr(), scope.as_ptr(), $color, 0);;
+					TOKEN = $crate::MicroProfileGetToken(group.as_ptr(), scope.as_ptr(), $color, 0);
 				});
 				$crate::MicroProfileEnter(TOKEN);	
 			}


### PR DESCRIPTION
Fixes this error I got when trying to use the two parameter scope macro overload.
```
error: cannot find macro `scope` in this scope
   --> src\main.rs:129:9
    |
129 |         microprofile::scope!("MainState", "update");
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

error: aborting due to previous error
```
Which was caused by a scoping problem, probably didn't show up in earlier rust versions?
Tried to repro this error in the tests, but couldn't figure out how.